### PR TITLE
Add emotion chip and admin functions

### DIFF
--- a/brain.ts
+++ b/brain.ts
@@ -153,4 +153,57 @@ export default class Brain extends EventEmitter {
     users[user.id] = user;
     this.set("users", users);
   }
+
+  // Categories
+  //
+  // This is a simple way to manage a series of grouped items for the bot, dynamically.
+  // A good example is a bot that replies to a certain phrase with a random gif. If the list of gifs
+  // is hard coded in the plugin, it will get boring eventually. This lets the plugin register a
+  // list of default gifs, then a user can add more gifs to the category, and when a phrase triggers
+  // the plugin, it fetchs a random item. The items are stored as strings, but could be response
+  // phrases, image links, or serialized objects.
+  CATEGORY_KEY = "categories";
+  public listCategories(): string[] {
+    let allItems = this.get(this.CATEGORY_KEY) || {};
+    return Object.keys(allItems);
+  }
+
+  public addItemToCategory(category: string, item: string) {
+    let allItems = this.get(this.CATEGORY_KEY) || {};
+    if (!allItems[category]) {
+      allItems[category] = [];
+    }
+    allItems[category].push(item);
+    this.set(this.CATEGORY_KEY, allItems);
+  }
+
+  public removeItemAtIndexInCategory(category: string, index: number) {
+    let allItems = this.get(this.CATEGORY_KEY) || {};
+    let items = allItems[category] || [];
+    items.splice(index, 1);
+    allItems[category] = items;
+    this.set(this.CATEGORY_KEY, allItems);
+  }
+
+  public getRandomItemFromCategory(category: string): string {
+    let combined = this.listItemsInCategory(category);
+    return combined[Math.floor(Math.random() * combined.length)];
+  }
+
+  public listItemsInCategory(category: string): string[] {
+    let allItems = this.get(this.CATEGORY_KEY) || {};
+    let items = allItems[category] || [];
+    return items;
+  }
+
+  public registerDefaultsForCateogry(category: string, items: string[]) {
+    let allItems = this.get(this.CATEGORY_KEY) || {};
+    let existingItems = allItems[category] || [];
+    if (existingItems.length > 0) {
+      return;
+    }
+    this.robot.logger.debug(`[brain] Loading defaults for category ${category}`);
+    allItems[category] = items;
+    this.set(this.CATEGORY_KEY, allItems);
+  }
 }

--- a/config.ts
+++ b/config.ts
@@ -10,10 +10,17 @@ export default class Config {
   adapters = ["./adapters/slack", "./adapters/twilio", "./adapters/alexa"];
 
   plugins = [
+    // Core plugins
     "./plugins/users",
     "./plugins/mongo-brain",
+    "./plugins/admin",
+
+    // Demo plugins
     // "./plugins/log",
     // "./plugins/echo",
+
+    // Extra plugins (should be moved to an external config file)
+    "./plugins/emotionChip",
     "./plugins/forecastio",
     "./plugins/inspirationalQuote",
     "./plugins/cta",
@@ -37,6 +44,7 @@ export default class Config {
     "../node_modules/hubot-scripts/src/scripts/go-for-it.coffee",
     "../node_modules/hubot-scripts/src/scripts/xkcd.coffee",
   ];
+  ADMIN_USERNAMES = ["josh"];
   UBER_CLIENT_ID = "";
   UBER_CLIENT_SECRET = "";
   UBER_SERVER_TOKEN = "";

--- a/plugins/admin.ts
+++ b/plugins/admin.ts
@@ -1,0 +1,73 @@
+"use strict";
+// Description:
+//   Admin functions for managing the bot.
+//
+// Configuration:
+//   ADMIN_USERNAMES - a list of user names that are allowed to run these functions
+//
+// Author:
+//   pcsforeducation
+
+import Config from "../config";
+import Response from "../response";
+import Robot from "../robot";
+import User from "../user";
+
+// Only support sending admin commands via Slack right now
+// TODO this should just wrap the response callback
+function checkAdmin(config: Config, user: User) {
+  return config.ADMIN_USERNAMES.indexOf(user.slack.name) > -1;
+}
+
+function listItems(items) {
+  return items.map((item, index) => `${index}: ${item}\n`).join("");
+}
+
+export default function(robot: Robot) {
+  robot.respond(/show categories/i, {}, (res: Response) => {
+    if (!checkAdmin(robot.config, res.message.user)) {
+      res.reply("Sorry, only available to admins.");
+      return;
+    }
+
+    let categories = robot.brain.listCategories();
+    res.reply(`Categories: ${categories.join("\n")}`);
+  });
+
+  robot.respond(/add item (.+) to (\w+)/i, {}, (res: Response) => {
+    if (!checkAdmin(robot.config, res.message.user)) {
+      res.reply("Sorry, only available to admins.");
+      return;
+    }
+
+    let item = res.match[1];
+    let category = res.match[2];
+    robot.brain.addItemToCategory(category, item);
+    let currentItems = robot.brain.listItemsInCategory(category);
+    res.reply(`Added ${item} to ${category}. Current items:\n${listItems(currentItems)}`);
+  });
+
+  robot.respond(/show items in (\w+)/i, {}, (res: Response) => {
+    if (!checkAdmin(robot.config, res.message.user)) {
+      res.reply("Sorry, only available to admins.");
+      return;
+    }
+
+    let category = res.match[1];
+    let currentItems = robot.brain.listItemsInCategory(category);
+    res.reply(`Current items in ${category}:\n${listItems(currentItems)}`);
+  });
+
+  robot.respond(/remove item (\d+) in (\w+)/i, {}, (res: Response) => {
+    if (!checkAdmin(robot.config, res.message.user)) {
+      res.reply("Sorry, only available to admins.");
+      return;
+    }
+    let index = res.match[1];
+    let category = res.match[2];
+    robot.brain.removeItemAtIndexInCategory(category, index);
+
+    let currentItems = robot.brain.listItemsInCategory(category);
+    res.reply(`Current items in ${category}:\n${listItems(currentItems)}`);
+  });
+}

--- a/plugins/emotionChip.ts
+++ b/plugins/emotionChip.ts
@@ -1,0 +1,62 @@
+"use strict";
+// Description:
+//   Make the bot more human. Feel free to disable for maximum efficiency. But this will make the
+//   bot sad.
+//
+// Commands:
+//   hubot hello - the bot replies in a very human manner
+//
+// Author:
+//   pcsforeducation
+
+import Response from "../response";
+import Robot from "../robot";
+
+function hello(robot: Robot) {
+  const HELLO_CATEGORY = "emotionChipHello";
+  robot.brain.registerDefaultsForCateogry(HELLO_CATEGORY, [
+    "hello!",
+    "hi :)",
+    "how's it going?",
+  ]);
+
+  robot.respond(/hello/i, {}, (res: Response) => {
+    let item = robot.brain.getRandomItemFromCategory(HELLO_CATEGORY);
+    res.reply(item);
+  });
+}
+
+function howAreYou(robot: Robot) {
+  const HELLO_CATEGORY = "emotionChipHowAreYou";
+  robot.brain.registerDefaultsForCateogry(HELLO_CATEGORY, [
+    "me rn: https://media.giphy.com/media/1Mng0gXC5Tpcs/giphy.gif",
+    "pretty dang good, how are you?",
+    "https://media.giphy.com/media/mIZ9rPeMKefm0/giphy.gif",
+  ]);
+
+  robot.respond(/how are you/i, {}, (res: Response) => {
+    let item = robot.brain.getRandomItemFromCategory(HELLO_CATEGORY);
+    res.reply(item);
+  });
+}
+
+// People love swearing at bots for some reason
+function fuckyou(robot: Robot) {
+  const HELLO_CATEGORY = "emotionChipFuckYou";
+  robot.brain.registerDefaultsForCateogry(HELLO_CATEGORY, [
+    "rude!",
+    "right back at you...",
+    "https://media.giphy.com/media/L4HWjj0sIXYty/giphy.gif",
+  ]);
+
+  robot.respond(/fuck you/i, {}, (res: Response) => {
+    let item = robot.brain.getRandomItemFromCategory(HELLO_CATEGORY);
+    res.reply(item);
+  });
+}
+
+export default function(robot: Robot) {
+  hello(robot);
+  howAreYou(robot);
+  fuckyou(robot);
+}

--- a/plugins/mongo-brain.ts
+++ b/plugins/mongo-brain.ts
@@ -62,7 +62,7 @@ export default function(robot) {
           if (isEqual(cache[k], v)) {
             continue;
           }
-          robot.logger.debug(`[mongo-brain] save \"${k}\" into mongodb-brain`);
+          // robot.logger.debug(`[mongo-brain] save \"${k}\" into mongodb-brain`);
           cache[k] = deepClone(v);
           collection.update(
             {

--- a/server.ts
+++ b/server.ts
@@ -10,6 +10,7 @@ import Robot from "./robot";
 // create a bot
 let config = new Config();
 let robot = new Robot(config);
+robot.init();
 
 process.on("uncaughtException", err => {
   console.log(`uncaught exception: ${err}: ${err.stack}`); // tslint:disable-line


### PR DESCRIPTION
Add categories, a set of values to respond with in certain situtations.
This allows the bot to respond with a random response from a
configurable list. The admin functions allow adding and remove items
from the categories. Add emotion chip as a simple demonstration of
categories, along with a few response to make the bot a little more
friendly (as well as responding to hostility!).

Closes #28, #29